### PR TITLE
Update the setup command to may receive the organization project and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ python3 -m TNTGitHook --setup
 
 It will prompt you for the organization, project and role names (they must match exactly with the ones on TNT, otherwise tool will complain).
 
+If you don't want the prompt for each command due:
+- To having several repositories to manage.
+- Want to use the setup in a script.
+
+Can use the following command instead that will not require any prompt to do the setup:
+
+**This configuration is per git repository!**
+
+```bash
+python3 -m TNTGitHook --setup --organization "ORGANIZATION" --project "PROJECT" --role "ROLE"
+```
+
 
 ### Manual Setup
 
@@ -173,7 +185,7 @@ And give it execution permission:
 ```bash
 chmod +x /usr/local/bin/tnt_git_hook.sh
 ```
-### Build release 
+### Build release
 
 To build Pypi, modify setup.py accordingly (versions, name, etc) package.
 Verify that you don't have old execution folders:

--- a/TNTGitHook/__init__.py
+++ b/TNTGitHook/__init__.py
@@ -22,6 +22,11 @@ def main(argv=None):
     parser.add_argument('--remote', help="Remote repo URL", required=False)
     parser.add_argument('--config', help="Config file", required=False)
 
+    parser.add_argument('--organization', help="For setup: The organization. By default require input", required=False, default="")
+    parser.add_argument('--project', help="For setup: The project. By default require input", required=False, default="")
+    parser.add_argument('--role', help="For setup: The role. By default require input", required=False, default="")
+
+
     args = parser.parse_args()
     config = Config.config(args.debug)
 
@@ -30,7 +35,7 @@ def main(argv=None):
         return
 
     if args.setup:
-        setup(config)
+        setup(config, args.organization, args.project, args.role)
         return
 
     config_file = args.config or DEFAULT_CONFIG_FILE_PATH

--- a/TNTGitHook/hook.py
+++ b/TNTGitHook/hook.py
@@ -58,12 +58,21 @@ class PrjConfig:
         return "###Autocreated evidence###\n(DO NOT DELETE)"
 
 
-def setup_config(config):
+def setup_config(config:Config, selected_organization:str, selected_project:str, selected_role:str):
+    if selected_organization == "":
+        selected_organization = input("Organization: ")
+
+    if selected_project == "":
+        selected_project = input("Project: ")
+
+    if selected_role == "":
+        selected_role = input("Role: ")
+
     try:
         headers = generate_request_headers(config)
-        organization = check_organization_exists(config, headers, input("Organization: "))
-        project = check_project_exists(config, headers, organization, input("Project: "))
-        role = check_role_exists(config, headers, project, input("Role: "))
+        organization = check_organization_exists(config, headers, selected_organization)
+        project = check_project_exists(config, headers, organization, selected_project)
+        role = check_role_exists(config, headers, project, selected_role)
 
         path = DEFAULT_CONFIG_FILE_PATH
         prj_config = PrjConfig()

--- a/TNTGitHook/hook_setup.py
+++ b/TNTGitHook/hook_setup.py
@@ -25,12 +25,10 @@ def write_hook():
     write_hook_script()
     print("Hook written")
 
-
-def setup(config: Config):
+def setup(config: Config, organization:str, project: str, role: str):
     write_hook_script()
     write_pre_push_script()
-    setup_config(config)
-
+    setup_config(config, organization, project, role)
 
 def write_pre_push_script():
     pre_push = PrePush()


### PR DESCRIPTION
Update the setup command to don't prompt the organization, project and role.
Useful when having multiples repositories to setup.

Setup command with prompt: 
`python3 -m TNTGitHook --setup`

Setup command without prompt: 
`python3 -m TNTGitHook --setup --organization "ORGANIZATION" --project "PROJECT" --role "ROLE"
`